### PR TITLE
Add initial iOS book exchange app skeleton

### DIFF
--- a/BookExchangeApp/AppDelegate.swift
+++ b/BookExchangeApp/AppDelegate.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+}

--- a/BookExchangeApp/Models/Book.swift
+++ b/BookExchangeApp/Models/Book.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Book: Codable {
+    let id: UUID
+    var title: String
+    var author: String
+    var genre: String?
+    var condition: String?
+    var ownerId: UUID
+}

--- a/BookExchangeApp/Models/User.swift
+++ b/BookExchangeApp/Models/User.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct User: Codable {
+    let id: UUID
+    var username: String
+    var email: String
+    var passwordHash: String
+    var preferredGenres: [String]
+
+    static func hashPassword(_ password: String) -> String {
+        return String(password.reversed())
+    }
+}

--- a/BookExchangeApp/SceneDelegate.swift
+++ b/BookExchangeApp/SceneDelegate.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
+        window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
+        window?.makeKeyAndVisible()
+    }
+}

--- a/BookExchangeApp/ViewControllers/BookListViewController.swift
+++ b/BookExchangeApp/ViewControllers/BookListViewController.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+class BookListViewController: UITableViewController {
+
+    private var books: [Book] = [
+        Book(id: UUID(), title: "1984", author: "George Orwell", genre: "Dystopian", condition: "Good", ownerId: UUID()),
+        Book(id: UUID(), title: "The Hobbit", author: "J.R.R. Tolkien", genre: "Fantasy", condition: "Fair", ownerId: UUID())
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Available Books"
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return books.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        let book = books[indexPath.row]
+        cell.textLabel?.text = "\(book.title) by \(book.author)"
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let book = books[indexPath.row]
+        let alert = UIAlertController(title: book.title, message: "Author: \(book.author)", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}

--- a/BookExchangeApp/ViewControllers/LoginViewController.swift
+++ b/BookExchangeApp/ViewControllers/LoginViewController.swift
@@ -1,0 +1,56 @@
+import UIKit
+
+class LoginViewController: UIViewController {
+
+    private let usernameField = UITextField()
+    private let passwordField = UITextField()
+    private let loginButton = UIButton(type: .system)
+    private let signupButton = UIButton(type: .system)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = "BookSwap"
+
+        setupViews()
+    }
+
+    private func setupViews() {
+        usernameField.placeholder = "Username"
+        usernameField.borderStyle = .roundedRect
+
+        passwordField.placeholder = "Password"
+        passwordField.borderStyle = .roundedRect
+        passwordField.isSecureTextEntry = true
+
+        loginButton.setTitle("Log In", for: .normal)
+        loginButton.addTarget(self, action: #selector(loginTapped), for: .touchUpInside)
+
+        signupButton.setTitle("Sign Up", for: .normal)
+        signupButton.addTarget(self, action: #selector(signupTapped), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [usernameField, passwordField, loginButton, signupButton])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+        ])
+    }
+
+    @objc private func loginTapped() {
+        let listVC = BookListViewController()
+        navigationController?.pushViewController(listVC, animated: true)
+    }
+
+    @objc private func signupTapped() {
+        let alert = UIAlertController(title: "Sign Up", message: "Signup flow not yet implemented.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold iOS app with UIKit including app and scene delegates
- add book and user data models
- implement basic login and book list view controllers

## Testing
- `swiftc BookExchangeApp/Models/Book.swift BookExchangeApp/Models/User.swift -emit-library -o /tmp/ModelsLib.so`
- `ls /tmp | head`

------
https://chatgpt.com/codex/tasks/task_e_68995f57c1a483319c13b51dfd2e274b